### PR TITLE
Ajustada linha de validação da inscrição estadual. Função re.escape e…

### DIFF
--- a/nfe/sped/nfe/processing/xml.py
+++ b/nfe/sped/nfe/processing/xml.py
@@ -79,7 +79,7 @@ def check_partner(company, cnpj_cpf, estado=None, ie=None):
             '',
             cnpj_cpf or ''))
     if ie and ie.lower() != 'isento':
-        ie = (re.sub('[%]' % re.scape(string.punctuation), '', ie or ''))
+        ie = (re.sub('[%s]' % re.escape(string.punctuation), '', ie or ''))
     return p.consultar_cadastro(estado, ie, cnpj_cpf)
 
 


### PR DESCRIPTION
…stava como "re.scape" gerando erro.

Corrigido erro ao consultar sefaz, acusando mensagem "python 'module' object has no attribute scape".
