### PR TITLE
Correção em chave de acesso - prefixo NFe retirado

### DIFF
--- a/nfe_import/service/nfe_serializer.py
+++ b/nfe_import/service/nfe_serializer.py
@@ -119,7 +119,7 @@ class NFeSerializer(object):
         res['supplier_invoice_number'] = self.nfe.infNFe.ide.nNF.valor
         res['date_in_out'] = datetime.now()
         res['nfe_purpose'] = str(self.nfe.infNFe.ide.finNFe.valor)
-        res['nfe_access_key'] = self.nfe.infNFe.Id.valor
+        res['nfe_access_key'] = self.nfe.infNFe.Id.valor[3:]
         res['nat_op'] = self.nfe.infNFe.ide.natOp.valor
         res['ind_final'] = self.nfe.infNFe.ide.indFinal.valor
         res['ind_pres'] = self.nfe.infNFe.ide.indPres.valor


### PR DESCRIPTION
No XML do SEFAZ, o valor da identificação da NFe vem como:

```
<infNFe Id="NFe35160509371574000140550010000140061040820003" versao="3.10">
```

O valor da chave de acesso que precisamos é apenas a parte depois do `NFe`:

```
35160509371574000140550010000140061040820003
```
